### PR TITLE
fix(core): improve overlay management 

### DIFF
--- a/packages/core/CHANGELOG.md
+++ b/packages/core/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @react-overlay-manager/core
 
+## 0.3.0
+
+### Minor Changes
+
+- correctly reveal nearest nonclosing overlay when closing topmost overlay
+
 ## 0.2.2
 
 ### Patch Changes

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@react-overlay-manager/core",
-  "version": "0.2.2",
+  "version": "0.3.0",
   "private": false,
   "type": "module",
   "description": "A lightweight React overlay management library with full TypeScript support",

--- a/packages/devtools/CHANGELOG.md
+++ b/packages/devtools/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @react-overlay-manager/devtools
 
+## 0.1.5
+
+### Patch Changes
+
+- Updated dependencies
+  - @react-overlay-manager/core@0.3.0
+
 ## 0.1.4
 
 ### Patch Changes

--- a/packages/devtools/package.json
+++ b/packages/devtools/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@react-overlay-manager/devtools",
-  "version": "0.1.4",
+  "version": "0.1.5",
   "private": false,
   "type": "module",
   "description": "Developer tools for React Overlay Manager - visual debugging and management interface",


### PR DESCRIPTION
to correctly reveal nearest nonclosing overlay when closing topmost overlay\n\n- Updated logic to skip overlays that are currently closing, ensuring the nearest non-closing overlay is shown.\n- Added a test case to verify this behavior when multiple overlays are involved.